### PR TITLE
Remove useless configuration options

### DIFF
--- a/res/config.ini
+++ b/res/config.ini
@@ -59,12 +59,6 @@
 # Input boxes length
 #input_len = 34
 
-# Max input sizes
-#max_desktop_len = 100
-#max_login_len = 255
-#max_password_len = 255
-
-
 # Input box active by default on startup
 #default_input = 2
 

--- a/src/config.c
+++ b/src/config.c
@@ -156,9 +156,6 @@ void config_load(const char *cfg_path) {
 		{"load", &config.load, config_handle_bool},
 		{"margin_box_h", &config.margin_box_h, config_handle_u8},
 		{"margin_box_v", &config.margin_box_v, config_handle_u8},
-		{"max_desktop_len", &config.max_desktop_len, config_handle_u8},
-		{"max_login_len", &config.max_login_len, config_handle_u8},
-		{"max_password_len", &config.max_password_len, config_handle_u8},
 		{"mcookie_cmd", &config.mcookie_cmd, config_handle_str},
 		{"min_refresh_delta", &config.min_refresh_delta, config_handle_u16},
 		{"path", &config.path, config_handle_str},
@@ -265,9 +262,6 @@ void config_defaults() {
 	config.load = true;
 	config.margin_box_h = 2;
 	config.margin_box_v = 1;
-	config.max_desktop_len = 100;
-	config.max_login_len = 255;
-	config.max_password_len = 255;
 	config.mcookie_cmd = strdup("/usr/bin/mcookie");
 	config.min_refresh_delta = 5;
 	config.path =

--- a/src/config.h
+++ b/src/config.h
@@ -77,9 +77,6 @@ struct config {
 	bool load;
 	uint8_t margin_box_h;
 	uint8_t margin_box_v;
-	uint8_t max_desktop_len;
-	uint8_t max_login_len;
-	uint8_t max_password_len;
 	char *mcookie_cmd;
 	uint16_t min_refresh_delta;
 	char *path;

--- a/src/inputs.c
+++ b/src/inputs.c
@@ -84,6 +84,23 @@ void input_text(struct text *target) {
 	target->y = 0;
 }
 
+void input_text_resize(struct text *target, int64_t new_size) {
+	if(new_size <= target->len) {
+		return;
+	}
+
+	target->len = new_size;
+
+	const ssize_t end_offset = target->end - target->text;
+	const ssize_t cur_offset = target->cur - target->text;
+	const ssize_t vstart_offset = target->visible_start- target->text;
+
+	target->text = realloc_or_throw(target->text, target->len);
+	target->end = target->text + end_offset;
+	target->cur = target->text + cur_offset;
+	target->visible_start = target->text + vstart_offset;
+}
+
 void input_desktop_free(struct desktop *target) {
 	if(target != NULL) {
 		for(uint16_t i = 0; i < target->len; ++i) {
@@ -180,16 +197,7 @@ void input_text_write(struct text *target, char ascii) {
 	}
 
 	if((target->end - target->text + 1) >= target->len) {
-		target->len *= 2;
-
-		const ssize_t end_offset = target->end - target->text;
-		const ssize_t cur_offset = target->cur - target->text;
-		const ssize_t vstart_offset = target->visible_start- target->text;
-
-		target->text = realloc_or_throw(target->text, target->len);
-		target->end = target->text + end_offset;
-		target->cur = target->text + cur_offset;
-		target->visible_start = target->text + vstart_offset;
+		input_text_resize(target, 2*target->len);
 	}
 
 	// moves the text to the right to add space for the new ascii char

--- a/src/inputs.c
+++ b/src/inputs.c
@@ -71,22 +71,15 @@ void input_desktop(struct desktop *target) {
 #endif
 }
 
-void input_text(struct text *target, uint64_t len) {
-	target->text = malloc_or_throw(len + 1);
+void input_text(struct text *target) {
+	target->len = 32;
+	target->text = malloc_or_throw(sizeof(char)*target->len);
 
-	int ok = mlock(target->text, len + 1);
-
-	if(ok < 0) {
-		dgn_throw(DGN_MLOCK);
-		return;
-	}
-
-	memset(target->text, 0, len + 1);
+	memset(target->text, 0, target->len);
 
 	target->cur = target->text;
 	target->end = target->text;
 	target->visible_start = target->text;
-	target->len = len;
 	target->x = 0;
 	target->y = 0;
 }
@@ -111,7 +104,6 @@ void input_desktop_free(struct desktop *target) {
 
 void input_text_free(struct text *target) {
 	memset(target->text, 0, target->len);
-	munlock(target->text, target->len + 1);
 	free(target->text);
 }
 
@@ -187,14 +179,25 @@ void input_text_write(struct text *target, char ascii) {
 		        // ascii
 	}
 
-	if((target->end - target->text + 1) < target->len) {
-		// moves the text to the right to add space for the new ascii char
-		memcpy(target->cur + 1, target->cur, target->end - target->cur);
-		++(target->end);
-		// adds the new char and moves the cursor to the right
-		*(target->cur) = ascii;
-		input_text_right(target);
+	if((target->end - target->text + 1) >= target->len) {
+		target->len *= 2;
+
+		const ssize_t end_offset = target->end - target->text;
+		const ssize_t cur_offset = target->cur - target->text;
+		const ssize_t vstart_offset = target->visible_start- target->text;
+
+		target->text = realloc_or_throw(target->text, target->len);
+		target->end = target->text + end_offset;
+		target->cur = target->text + cur_offset;
+		target->visible_start = target->text + vstart_offset;
 	}
+
+	// moves the text to the right to add space for the new ascii char
+	memcpy(target->cur + 1, target->cur, target->end - target->cur);
+	++(target->end);
+	// adds the new char and moves the cursor to the right
+	*(target->cur) = ascii;
+	input_text_right(target);
 }
 
 void input_text_delete(struct text *target) {
@@ -213,7 +216,7 @@ void input_text_backspace(struct text *target) {
 }
 
 void input_text_clear(struct text *target) {
-	memset(target->text, 0, target->len + 1);
+	memset(target->text, 0, target->len);
 	target->cur = target->text;
 	target->end = target->text;
 	target->visible_start = target->text;

--- a/src/inputs.h
+++ b/src/inputs.h
@@ -35,7 +35,7 @@ struct desktop {
 void handle_desktop(void *input_struct, struct tb_event *event);
 void handle_text(void *input_struct, struct tb_event *event);
 void input_desktop(struct desktop *target);
-void input_text(struct text *target, uint64_t len);
+void input_text(struct text *target);
 void input_desktop_free(struct desktop *target);
 void input_text_free(struct text *target);
 void input_desktop_right(struct desktop *target);

--- a/src/inputs.h
+++ b/src/inputs.h
@@ -35,6 +35,7 @@ struct desktop {
 void handle_desktop(void *input_struct, struct tb_event *event);
 void handle_text(void *input_struct, struct tb_event *event);
 void input_desktop(struct desktop *target);
+void input_text_resize(struct text *target, int64_t new_size);
 void input_text(struct text *target);
 void input_desktop_free(struct desktop *target);
 void input_text_free(struct text *target);

--- a/src/main.c
+++ b/src/main.c
@@ -99,8 +99,8 @@ int main(int argc, char **argv) {
 	struct text login;
 	struct text password;
 	input_desktop(&desktop);
-	input_text(&login, config.max_login_len);
-	input_text(&password, config.max_password_len);
+	input_text(&login);
+	input_text(&password);
 
 	if(dgn_catch()) {
 		config_free();

--- a/src/utils.c
+++ b/src/utils.c
@@ -55,6 +55,13 @@ void draw_cells(uint16_t x, uint16_t y, uint16_t w, uint16_t h, struct tb_cell *
 	}
 }
 
+/**
+ * Reads a line from `file`. `buf_sz` and `buf` can be used to attempt to reuse 
+ * a buffer. Said buffer will be `realloc`ed when necessary, and its size will 
+ * be written to `buf_sz`.
+ *
+ * Note: if `buf` is non-null, buf_sz must point to the buffer's size.
+ */
 static char *mfgets(FILE *file, char *buf, size_t *buf_sz) {
 	if(buf_sz == NULL) {
 		size_t b = 32;
@@ -63,7 +70,7 @@ static char *mfgets(FILE *file, char *buf, size_t *buf_sz) {
 
 	if(buf == NULL) {
 		*buf_sz = 32;
-		char *buf = malloc_or_throw(sizeof(*buf)**buf_sz);
+		buf = malloc_or_throw(sizeof(*buf)**buf_sz);
 	}
 
 	size_t char_idx = 0;
@@ -272,6 +279,8 @@ void load(struct desktop *desktop, struct text *login) {
 	char *line = mfgets(fp, NULL, &line_size);
 
 	int len = strlen(line);
+	input_text_resize(login, len + 1);
+
 	strncpy(login->text, line, login->len);
 
 	if(len == 0) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -72,6 +72,7 @@ static char *mfgets(FILE *file, char *buf, size_t *buf_sz) {
 
 	do {
 		ch = fgetc(file);
+
 		if(ch == EOF || ch == '\n' || ch == '\r') {
 			char_to_add = '\0';
 		} else {
@@ -82,6 +83,8 @@ static char *mfgets(FILE *file, char *buf, size_t *buf_sz) {
 			*buf_sz *= 2;
 			buf = realloc_or_throw(buf, *buf_sz * sizeof(*buf));
 		}
+
+		buf[char_idx] = char_to_add;
 
 		char_idx += 1;
 	} while(char_to_add != '\0');


### PR DESCRIPTION
Addresses issue #1

Removes the following configuration options
- max_desktop_len (unused)
- max_login_len (dynamically resize buffer on-the-fly)
- max_password_len (dynamically resize buffer on-the-fly)

### TODO:
- [ ]  Thoroughly test